### PR TITLE
Fix: Use fmt::format instead of std::format

### DIFF
--- a/httpd/include/httpd/logging.hpp
+++ b/httpd/include/httpd/logging.hpp
@@ -769,7 +769,7 @@ public:
 			fs::path filename;
 
 			if constexpr (LOG_MAXFILE_SIZE <= 0) {
-				auto logfile = std::format("{:04d}{:02d}{:02d}-{:02d}.log",
+				auto logfile = fmt::format("{:04d}{:02d}{:02d}-{:02d}.log",
 					ptm->tm_year + 1900,
 					ptm->tm_mon + 1,
 					ptm->tm_mday,
@@ -777,7 +777,7 @@ public:
 				filename = logpath / logfile;
 			} else {
 				auto utc_time = std::mktime(ptm);
-				auto logfile = std::format("{:04d}{:02d}{:02d}-{}.log",
+				auto logfile = fmt::format("{:04d}{:02d}{:02d}-{}.log",
 					ptm->tm_year + 1900,
 					ptm->tm_mon + 1,
 					ptm->tm_mday,


### PR DESCRIPTION
Fix the following error:
```
[ 98%] Building CXX object httpd/CMakeFiles/httpd.dir/src/main.cpp.o
In file included from /Users/yuyu/code/httpd/httpd/src/main.cpp:52:
/Users/yuyu/code/httpd/httpd/include/httpd/logging.hpp:772:20: error: call to 'format' is ambiguous
                                auto logfile = std::format("{:04d}{:02d}{:02d}-{:02d}.log",
                                               ^~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__format/format_functions.h:453:1: note: candidate function [with _Args = <int, int, int &, int &>]
format(format_string<_Args...> __fmt, _Args&&... __args) {
^
/Users/yuyu/code/httpd/third_party/fmt/include/fmt/core.h:2815:31: note: candidate function [with T = <int, int, int &, int &>]
FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
                              ^
In file included from /Users/yuyu/code/httpd/httpd/src/main.cpp:52:
/Users/yuyu/code/httpd/httpd/include/httpd/logging.hpp:780:20: error: call to 'format' is ambiguous
                                auto logfile = std::format("{:04d}{:02d}{:02d}-{}.log",
                                               ^~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__format/format_functions.h:453:1: note: candidate function [with _Args = <int, int, int &, long &>]
format(format_string<_Args...> __fmt, _Args&&... __args) {
^
/Users/yuyu/code/httpd/third_party/fmt/include/fmt/core.h:2815:31: note: candidate function [with T = <int, int, int &, long &>]
FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
```